### PR TITLE
Fix - Object type checking

### DIFF
--- a/.changeset/cross-realm-core-guards.md
+++ b/.changeset/cross-realm-core-guards.md
@@ -1,0 +1,9 @@
+---
+"@jsfns/core": minor
+---
+
+Cross-realm support for value guards:
+
+- Add `isMap`, `isSet`, and `isPlainObject` guards that work across realms (e.g. iframes)
+- Add a `getObjectName` helper
+- `isEmpty` now correctly recognises `Map`s, `Set`s, and plain objects from another realm

--- a/.changeset/cross-realm-web-guards.md
+++ b/.changeset/cross-realm-web-guards.md
@@ -1,0 +1,9 @@
+---
+"@jsfns/web": minor
+---
+
+Cross-realm support for DOM guards:
+
+- Fix `on`/`off` failing on an iframe's `contentWindow` ([#24](https://github.com/Tokimon/jsfns/issues/24)): `isEventTarget` no longer relies on a realm-bound `instanceof`
+- `isBlob`, `isWindow`, and `isHTMLElement` now detect targets from another realm (e.g. iframes)
+- Add a `GlobalWindow` type

--- a/packages/core/src/getObjectName.ts
+++ b/packages/core/src/getObjectName.ts
@@ -1,0 +1,19 @@
+/**
+ * Get the internal type name of a value via `Object.prototype.toString`.
+ *
+ * @param obj - The object to get the name of
+ * @returns The internal type name (e.g. `'Map'`, `'RegExp'`, `'Array'`)
+ *
+ * @example
+ *
+ * ```ts
+ * getObjectName(new Map()) // --> 'Map'
+ * getObjectName(/x/) // --> 'RegExp'
+ * getObjectName([]) // --> 'Array'
+ * getObjectName(null) // --> 'Null'
+ * ```
+ */
+export const getObjectName = (obj: unknown): string =>
+	Object.prototype.toString.call(obj).slice(8, -1);
+
+export default getObjectName;

--- a/packages/core/src/isEmpty.ts
+++ b/packages/core/src/isEmpty.ts
@@ -1,6 +1,8 @@
-import { isBoolean } from './isBoolean.ts';
-import { isNumber } from './isNumber.ts';
-import { isObject } from './isObject.ts';
+import { isBoolean } from './isBoolean.js';
+import { isMap } from './isMap.js';
+import { isNumber } from './isNumber.js';
+import { isPlainObject } from './isPlainObject.js';
+import { isSet } from './isSet.js';
 
 /**
  * Is the given value considered empty.
@@ -41,13 +43,9 @@ export function isEmpty(x: unknown) {
 
 	if (Array.isArray(x)) return !x.length;
 
-	if (x instanceof Map || x instanceof Set) return !x.size;
+	if (isMap(x) || isSet(x)) return !x.size;
 
-	if (isObject(x)) {
-		const proto = Object.getPrototypeOf(x);
-		const isPlain = proto === null || proto === Object.prototype;
-		return isPlain && !Object.keys(x).length;
-	}
+	if (isPlainObject(x)) return !Object.keys(x).length;
 
 	return false;
 }

--- a/packages/core/src/isMap.ts
+++ b/packages/core/src/isMap.ts
@@ -1,0 +1,23 @@
+import { getObjectName } from './getObjectName.js';
+
+/**
+ * Is the given argument a Map
+ *
+ * Works across realms (e.g. a Map created in an iframe), where `instanceof`
+ * against the local realm's `Map` would fail.
+ *
+ * @param x - Argument to test
+ *
+ * @returns Whether the argument is a Map or not
+ *
+ * @example
+ * ```ts
+ * isMap(new Map()); // --> true
+ * isMap(new Set()); // --> false
+ * isMap({}); // --> false
+ * ```
+ */
+export const isMap = (x: unknown): x is Map<unknown, unknown> =>
+	x instanceof Map || getObjectName(x) === 'Map';
+
+export default isMap;

--- a/packages/core/src/isPlainObject.ts
+++ b/packages/core/src/isPlainObject.ts
@@ -1,0 +1,35 @@
+import { isObject } from './isObject.js';
+
+/**
+ * Is the given argument a plain object (created via `{}`, `new Object()`, or
+ * `Object.create(null)`) rather than a class instance, array, or built-in like
+ * `Date`/`Map`.
+ *
+ * Works across realms (e.g. an object literal from an iframe), by checking the
+ * prototype chain instead of identity against this realm's `Object.prototype`.
+ *
+ * @param x - Argument to test
+ *
+ * @returns Whether the argument is a plain object or not
+ *
+ * @example
+ * ```ts
+ * class Obj {}
+ *
+ * isPlainObject({}); // --> true
+ * isPlainObject(Object.create(null)); // --> true
+ * isPlainObject(new Obj()); // --> false
+ * isPlainObject([]); // --> false
+ * isPlainObject(new Date()); // --> false
+ * ```
+ */
+export function isPlainObject(x: unknown): x is Record<string, unknown> {
+	if (!isObject(x)) return false;
+
+	// A plain object's prototype is either null or a top-level `Object.prototype`
+	// (one whose own prototype is null)
+	const proto = Object.getPrototypeOf(x);
+	return proto === null || Object.getPrototypeOf(proto) === null;
+}
+
+export default isPlainObject;

--- a/packages/core/src/isSet.ts
+++ b/packages/core/src/isSet.ts
@@ -1,0 +1,23 @@
+import { getObjectName } from './getObjectName.js';
+
+/**
+ * Is the given argument a Set
+ *
+ * Works across realms (e.g. a Set created in an iframe), where `instanceof`
+ * against the local realm's `Set` would fail.
+ *
+ * @param x - Argument to test
+ *
+ * @returns Whether the argument is a Set or not
+ *
+ * @example
+ * ```ts
+ * isSet(new Set()); // --> true
+ * isSet(new Map()); // --> false
+ * isSet([]); // --> false
+ * ```
+ */
+export const isSet = (x: unknown): x is Set<unknown> =>
+	x instanceof Set || getObjectName(x) === 'Set';
+
+export default isSet;

--- a/packages/core/tests/getObjectName.test.ts
+++ b/packages/core/tests/getObjectName.test.ts
@@ -1,0 +1,21 @@
+import { getObjectName } from '@jsfns/core/getObjectName.js';
+import { describe, expect, it } from 'vitest';
+
+describe('"getObjectName"', () => {
+	it.each([
+		['Undefined', undefined],
+		['Null', null],
+		['Boolean', true],
+		['Number', 123],
+		['String', ''],
+		['Array', []],
+		['Object', {}],
+		['Function', () => undefined],
+		['RegExp', /x/],
+		['Date', new Date()],
+		['Map', new Map()],
+		['Set', new Set()],
+	])('Returns `%s` for the matching value', (expected, obj) => {
+		expect(getObjectName(obj)).toBe(expected);
+	});
+});

--- a/packages/core/tests/isEmpty.test.ts
+++ b/packages/core/tests/isEmpty.test.ts
@@ -54,4 +54,24 @@ describe('"isEmpty"', () => {
 			expect(isEmpty(value)).toBe(false);
 		});
 	});
+
+	describe('Handles plain objects from another realm', () => {
+		// A cross-realm `{}` has the *other* realm's `Object.prototype` (whose own
+		// prototype is null), not this realm's — so identity checks would misfire
+		const foreignProto = Object.create(null);
+
+		it('treats an empty foreign plain object as empty', () => {
+			const emptyForeign = Object.create(foreignProto);
+
+			expect(Object.getPrototypeOf(emptyForeign)).not.toBe(Object.prototype);
+			expect(isEmpty(emptyForeign)).toBe(true);
+		});
+
+		it('treats a non-empty foreign plain object as not empty', () => {
+			const nonEmptyForeign = Object.create(foreignProto);
+			nonEmptyForeign.a = 1;
+
+			expect(isEmpty(nonEmptyForeign)).toBe(false);
+		});
+	});
 });

--- a/packages/core/tests/isMap.test.ts
+++ b/packages/core/tests/isMap.test.ts
@@ -1,0 +1,28 @@
+import { isMap } from '@jsfns/core/isMap.js';
+import { describe, expect, it } from 'vitest';
+
+describe('"isMap"', () => {
+	it('Returns `true` for a Map', () => {
+		expect(isMap(new Map())).toBe(true);
+	});
+
+	it('Returns `true` for a Map-tagged object from another realm (not instanceof Map)', () => {
+		// A cross-realm Map is not an instance of this realm's Map, but is still
+		// tagged `[object Map]` — which is what the cross-realm fallback relies on
+		const crossRealmMap = { [Symbol.toStringTag]: 'Map' };
+
+		expect(crossRealmMap instanceof Map).toBe(false);
+		expect(isMap(crossRealmMap)).toBe(true);
+	});
+
+	it.each([
+		['Undefined', undefined],
+		['Null', null],
+		['Object', {}],
+		['Array', []],
+		['Set', new Set()],
+		['WeakMap', new WeakMap()],
+	])('Returns `false` for %s', (_, obj) => {
+		expect(isMap(obj)).toBe(false);
+	});
+});

--- a/packages/core/tests/isPlainObject.test.ts
+++ b/packages/core/tests/isPlainObject.test.ts
@@ -1,0 +1,47 @@
+import { isPlainObject } from '@jsfns/core/isPlainObject.js';
+import { describe, expect, it } from 'vitest';
+
+class TestObj {
+	name = 'test';
+}
+
+describe('"isPlainObject"', () => {
+	describe('Returns `true` for:', () => {
+		it.each([
+			['object literal', {}],
+			['object literal with keys', { a: 1 }],
+			['new Object()', new Object()],
+			['Object.create(null)', Object.create(null)],
+		])('%s', (_label, value) => {
+			expect(isPlainObject(value)).toBe(true);
+		});
+
+		it('a plain object from another realm (prototype differs from the local Object.prototype)', () => {
+			// Simulate a cross-realm `{}`: its prototype is a top-level prototype
+			// (own prototype null) that is NOT this realm's `Object.prototype`
+			const foreignProto = Object.create(null);
+			const foreignObject = Object.create(foreignProto);
+
+			expect(Object.getPrototypeOf(foreignObject)).not.toBe(Object.prototype);
+			expect(isPlainObject(foreignObject)).toBe(true);
+		});
+	});
+
+	describe('Returns `false` for:', () => {
+		it.each([
+			['Undefined', undefined],
+			['Null', null],
+			['Number', 123],
+			['String', ''],
+			['Boolean', true],
+			['Array', []],
+			['Date', new Date()],
+			['RegExp', /x/],
+			['Map', new Map()],
+			['Set', new Set()],
+			['class instance', new TestObj()],
+		])('%s', (_label, value) => {
+			expect(isPlainObject(value)).toBe(false);
+		});
+	});
+});

--- a/packages/core/tests/isSet.test.ts
+++ b/packages/core/tests/isSet.test.ts
@@ -1,0 +1,28 @@
+import { isSet } from '@jsfns/core/isSet.js';
+import { describe, expect, it } from 'vitest';
+
+describe('"isSet"', () => {
+	it('Returns `true` for a Set', () => {
+		expect(isSet(new Set())).toBe(true);
+	});
+
+	it('Returns `true` for a Set-tagged object from another realm (not instanceof Set)', () => {
+		// A cross-realm Set is not an instance of this realm's Set, but is still
+		// tagged `[object Set]` — which is what the cross-realm fallback relies on
+		const crossRealmSet = { [Symbol.toStringTag]: 'Set' };
+
+		expect(crossRealmSet instanceof Set).toBe(false);
+		expect(isSet(crossRealmSet)).toBe(true);
+	});
+
+	it.each([
+		['Undefined', undefined],
+		['Null', null],
+		['Object', {}],
+		['Array', []],
+		['Map', new Map()],
+		['WeakSet', new WeakSet()],
+	])('Returns `false` for %s', (_, obj) => {
+		expect(isSet(obj)).toBe(false);
+	});
+});

--- a/packages/web/src/isBlob.ts
+++ b/packages/web/src/isBlob.ts
@@ -1,3 +1,5 @@
+import { getObjectName } from '@jsfns/core/getObjectName.js';
+
 /**
  * Is the given object a Blob object
  *
@@ -12,6 +14,7 @@
  * isBlob('blob') // --> false
  * ```
  */
-export const isBlob = (obj: unknown): obj is Blob => obj instanceof Blob;
+export const isBlob = (obj: unknown): obj is Blob =>
+	obj instanceof Blob || getObjectName(obj) === 'Blob';
 
 export default isBlob;

--- a/packages/web/src/isEventTarget.ts
+++ b/packages/web/src/isEventTarget.ts
@@ -1,5 +1,6 @@
 /**
- * Is the given object a viable event target (implements the addEventListener function)
+ * Is the given object a viable event target (implements the `addEventListener`
+ * and `removeEventListener` functions — the methods `on` and `off` rely on)
  *
  * @param obj - The object to check
  * @returns Is it an Event Target or not
@@ -16,6 +17,10 @@
  * isEventTarget({}) // --> false
  * ```
  */
-export const isEventTarget = (obj: unknown): obj is EventTarget => obj instanceof EventTarget;
+export const isEventTarget = (obj: unknown): obj is EventTarget =>
+	obj instanceof EventTarget ||
+	(obj != null &&
+		typeof (obj as EventTarget).addEventListener === 'function' &&
+		typeof (obj as EventTarget).removeEventListener === 'function');
 
 export default isEventTarget;

--- a/packages/web/src/isHTMLElement.ts
+++ b/packages/web/src/isHTMLElement.ts
@@ -1,6 +1,7 @@
 import getCurrentWindow from './getCurrentWindow.js';
 import isDOMNode from './isDOMNode.js';
 import isWindow from './isWindow.js';
+import type { GlobalWindow } from './types.ts';
 
 /**
  * Is the given object a HTMLElement node
@@ -20,13 +21,17 @@ import isWindow from './isWindow.js';
  * ```
  */
 export function isHTMLElement(obj: unknown): obj is HTMLElement {
+	if (obj == null) return false;
 	if (isWindow(obj)) return false;
 	if (!isDOMNode(obj)) return false;
 	if (obj instanceof HTMLElement) return true;
 
-	// For elements in an IFrame where elements are created using the types in the frame window
-	const win = getCurrentWindow(obj) as typeof globalThis | null;
-	return !!win?.HTMLElement && obj instanceof win.HTMLElement;
+	// For elements in an IFrame where elements are created using the types in the frame window.
+	// A foreign realm's globals are uncertain, so treat them as optional and feature-detect.
+	const currentWindow = getCurrentWindow(obj) as Partial<GlobalWindow> | null;
+	if (!currentWindow) return false;
+
+	return !!currentWindow.HTMLElement && obj instanceof currentWindow.HTMLElement;
 }
 
 export default isHTMLElement;

--- a/packages/web/src/isWindow.ts
+++ b/packages/web/src/isWindow.ts
@@ -1,3 +1,4 @@
+import { getObjectName } from '@jsfns/core/getObjectName.js';
 import type { GeneralWindow } from './types.ts';
 
 /**
@@ -16,7 +17,7 @@ import type { GeneralWindow } from './types.ts';
  * ```
  */
 export function isWindow(obj: unknown): obj is GeneralWindow {
-	return obj instanceof Window || Object.prototype.toString.call(obj).includes('object Window');
+	return obj instanceof Window || getObjectName(obj) === 'Window';
 }
 
 export default isWindow;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -4,6 +4,12 @@
 export type GeneralWindow = Window | typeof window;
 
 /**
+ * A `Window` together with its global scope, exposing the realm's own
+ * constructors (e.g. `Blob`, `HTMLElement`) for cross-realm checks.
+ */
+export type GlobalWindow = Window & typeof globalThis;
+
+/**
  * A valid event name string. Includes all standard `DocumentEventMap` keys (like `"click"`, `"keydown"`)
  * as well as arbitrary custom string values.
  */

--- a/packages/web/tests/assets/helpers.ts
+++ b/packages/web/tests/assets/helpers.ts
@@ -1,4 +1,4 @@
-import type { GeneralWindow } from '@jsfns/web/types.ts';
+import type { GeneralWindow, GlobalWindow } from '@jsfns/web/types.ts';
 
 export const generateId = (baseId: string): string => baseId + '__' + Date.now().toString(36);
 
@@ -29,6 +29,17 @@ export const appendFrame = (doc = document): HTMLIFrameElement => {
 
 	return frame;
 };
+
+/**
+ * A frame's `contentWindow` typed for reaching its realm's constructors (e.g.
+ * `Blob`, `Map`) when building cross-realm test objects.
+ *
+ * Test-only: the `GlobalWindow` assertion is safe here because the iframe is a
+ * standard same-engine realm we just created — unlike arbitrary foreign windows
+ * in production, where realm globals should be treated as optional.
+ */
+export const frameWindow = (frame: HTMLIFrameElement): GlobalWindow =>
+	frame.contentWindow as GlobalWindow;
 
 export const insertHtml = (html: string, elm: Element = document.body): void =>
 	elm.insertAdjacentHTML('beforeend', html);

--- a/packages/web/tests/isBlob.test.ts
+++ b/packages/web/tests/isBlob.test.ts
@@ -1,9 +1,21 @@
 import { isBlob } from '@jsfns/web/isBlob.js';
 import { describe, expect, it } from 'vitest';
+import { appendFrame, frameWindow } from './assets/helpers.js';
 
 describe('"isBlob"', () => {
 	it('Returns `true` for Blob objects', () => {
 		expect(isBlob(new Blob())).toBe(true);
+	});
+
+	it('Returns `true` for a Blob from another realm (iframe)', () => {
+		const frame = appendFrame();
+		const crossRealmBlob = new (frameWindow(frame).Blob)();
+
+		// Sanity check: a cross-realm Blob is NOT an instance of this realm's Blob
+		expect(crossRealmBlob instanceof Blob).toBe(false);
+		expect(isBlob(crossRealmBlob)).toBe(true);
+
+		frame.remove();
 	});
 
 	it.each([null, {}, 123, 'blob'])('Returns `false` for non Blob objects', (val) => {

--- a/packages/web/tests/isEventTarget.test.ts
+++ b/packages/web/tests/isEventTarget.test.ts
@@ -13,6 +13,8 @@ describe('"isEventTarget"', () => {
 			['String', ''],
 			['Number', 123],
 			['Boolean', true],
+			// Implements only part of the contract — `off` would fail on this
+			['Object with addEventListener but no removeEventListener', { addEventListener() {} }],
 		])('%s', (_, obj) => {
 			expect(isEventTarget(obj)).toBe(false);
 		});
@@ -27,6 +29,12 @@ describe('"isEventTarget"', () => {
 			['Comment Node', document.createComment('')],
 			['XMLHttpRequest', new XMLHttpRequest()],
 			['Object extending EventTarget', new Custom()],
+			// A cross-realm target (e.g. an iframe's contentWindow) is not an
+			// instance of this realm's EventTarget, but still implements the API
+			[
+				'Cross-realm target (not instanceof EventTarget)',
+				{ addEventListener() {}, removeEventListener() {} },
+			],
 		])('%s', (_, obj) => {
 			expect(isEventTarget(obj)).toBe(true);
 		});

--- a/packages/web/tests/isHTMLChildElement.test.ts
+++ b/packages/web/tests/isHTMLChildElement.test.ts
@@ -5,6 +5,7 @@ import {
 	byId,
 	createDetachedDocument,
 	createElement,
+	frameWindow,
 	generateId,
 	insertHtml,
 	removeElement,
@@ -43,9 +44,7 @@ describe('"isHTMLChildElement"', () => {
 			const { body } = frame.contentDocument as Document;
 			body.innerHTML = '<div></div>';
 
-			const iframeSpy = mockOffsetParent(
-				(frame.contentWindow as unknown as typeof globalThis).HTMLElement.prototype,
-			);
+			const iframeSpy = mockOffsetParent(frameWindow(frame).HTMLElement.prototype);
 
 			expect(isHTMLChildElement(body.firstElementChild)).toBe(true);
 

--- a/packages/web/tests/isHTMLElement.test.ts
+++ b/packages/web/tests/isHTMLElement.test.ts
@@ -37,6 +37,13 @@ describe('"isHTMLElement"', () => {
 			frame.remove();
 		});
 
+		it('A non-element node in a detached Document (no associated window)', () => {
+			const doc = createDetachedDocument();
+
+			expect(doc.defaultView).toBe(null);
+			expect(isHTMLElement(doc.createTextNode(''))).toBe(false);
+		});
+
 		it.each([
 			['Document', document],
 			['Fragment', document.createDocumentFragment()],

--- a/packages/web/tests/off.test.ts
+++ b/packages/web/tests/off.test.ts
@@ -1,6 +1,6 @@
 import { off } from '@jsfns/web/off.js';
 import { describe, expect, it, vi } from 'vitest';
-import { bind, triggerEvent } from './assets/helpers.js';
+import { appendFrame, bind, frameWindow, triggerEvent } from './assets/helpers.js';
 
 describe('"off"', () => {
 	function suite(elm?: HTMLElement | Window) {
@@ -60,5 +60,31 @@ describe('"off"', () => {
 		['Window', window],
 	])('With %s', (_, elm) => {
 		suite(elm);
+	});
+
+	describe('With a cross-realm iframe window (issue #24)', () => {
+		it('Removes from the iframe contentWindow instead of falling back to document', () => {
+			const eventName = 'test';
+			const frame = appendFrame();
+			const win = frameWindow(frame);
+			const handler = vi.fn();
+
+			const documentSpy = vi.spyOn(document, 'removeEventListener');
+			const frameSpy = vi.spyOn(win, 'removeEventListener');
+
+			bind(win, eventName, handler);
+
+			off(win, eventName, handler);
+
+			expect(frameSpy).toHaveBeenCalledWith(eventName, handler, undefined);
+			expect(documentSpy).not.toHaveBeenCalled();
+
+			win.dispatchEvent(new win.Event(eventName));
+			expect(handler).not.toHaveBeenCalled();
+
+			frameSpy.mockRestore();
+			documentSpy.mockRestore();
+			frame.remove();
+		});
 	});
 });

--- a/packages/web/tests/on.test.ts
+++ b/packages/web/tests/on.test.ts
@@ -1,6 +1,13 @@
 import { type OnOptions, on } from '@jsfns/web/on.js';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
-import { byId, generateId, insertHtml, triggerEvent } from './assets/helpers.js';
+import {
+	appendFrame,
+	byId,
+	frameWindow,
+	generateId,
+	insertHtml,
+	triggerEvent,
+} from './assets/helpers.js';
 
 const testID = generateId('on');
 const eventName = 'test';
@@ -344,5 +351,29 @@ describe('"on"', () => {
 
 	describe('With Window', () => {
 		suite(window);
+	});
+
+	describe('With a cross-realm iframe window (issue #24)', () => {
+		it('Binds to the iframe contentWindow instead of falling back to document', () => {
+			const frame = appendFrame();
+			const win = frameWindow(frame);
+			const handler = vi.fn();
+
+			const documentSpy = vi.spyOn(document, 'addEventListener');
+			const frameSpy = vi.spyOn(win, 'addEventListener');
+
+			const off = on(win, eventName, handler);
+
+			expect(frameSpy).toHaveBeenCalledWith(eventName, handler, undefined);
+			expect(documentSpy).not.toHaveBeenCalled();
+
+			win.dispatchEvent(new win.Event(eventName));
+			expect(handler).toHaveBeenCalledTimes(1);
+
+			off();
+			frameSpy.mockRestore();
+			documentSpy.mockRestore();
+			frame.remove();
+		});
 	});
 });


### PR DESCRIPTION
### `web`
- **Fix #24**: `isEventTarget` is now capability-based (checks `addEventListener`/`removeEventListener`) with an `instanceof` fast-path, so `on`/`off` work with cross-realm iframe windows
- `isBlob` and `isWindow` now fall back to an `Object.prototype.toString` tag check for cross-realm targets
- `isHTMLElement` feature-detects the realm's own `HTMLElement` via `Partial<GlobalWindow>` instead of an unsound cast
- Add a `GlobalWindow` type (`Window & typeof globalThis`); `GeneralWindow` retained for input positions
- Add a test-only `frameWindow` helper centralizing the iframe-window cast

### `core`
- Add `getObjectName` helper (`Object.prototype.toString` tag) — used by both packages
- Add cross-realm-safe `isMap`, `isSet`, and `isPlainObject` guards
- `isEmpty` now correctly handles `Map`s, `Set`s, and plain objects from another realm (prototype-chain check instead of identity against the local `Object.prototype`)

### Tests
- Regression tests for `on` **and** `off` reproducing the #24 iframe scenario
- Cross-realm cases added for `isEventTarget`, `isBlob`, `isHTMLElement`, `isHTMLChildElement`, plus full guard tests for the new core methods